### PR TITLE
✨ TsConfig Parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "configuru",
       "version": "1.0.4",
       "dependencies": {
-        "jsonc-parser": "^3.2.0"
+        "jsonc-parser": "^3.2.0",
+        "typescript": "^5.6.2"
       },
       "devDependencies": {
         "@ackee/styleguide-backend-config": "^1.0.1",
@@ -22,8 +23,7 @@
         "glob": "^8.1.0",
         "mocha": "^10.2.0",
         "prettier": "^3.6.2",
-        "tsx": "^4.20.6",
-        "typescript": "^5.6.2"
+        "tsx": "^4.20.6"
       },
       "engines": {
         "vscode": "^1.79.0"
@@ -9556,7 +9556,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -101,10 +101,10 @@
     "glob": "^8.1.0",
     "mocha": "^10.2.0",
     "prettier": "^3.6.2",
-    "tsx": "^4.20.6",
-    "typescript": "^5.6.2"
+    "tsx": "^4.20.6"
   },
   "dependencies": {
-    "jsonc-parser": "^3.2.0"
+    "jsonc-parser": "^3.2.0",
+    "typescript": "^5.6.2"
   }
 }

--- a/src/components/config-ts-parser.ts
+++ b/src/components/config-ts-parser.ts
@@ -1,0 +1,275 @@
+import * as ts from 'typescript'
+
+export type ConfigTsKeyType = 'string' | 'number' | 'bool' | 'json' | 'custom'
+
+export interface ConfigTsKey {
+  key: string
+  position: {
+    start: number
+    end: number
+  }
+  type: ConfigTsKeyType
+  isNullable: boolean
+  isHidden: boolean
+}
+
+const isCreateLoaderCall = (node: ts.Node): node is ts.CallExpression => {
+  if (!ts.isCallExpression(node)) {
+    return false
+  }
+  if (!ts.isIdentifier(node.expression)) {
+    return false
+  }
+  return node.expression.text === 'createLoader'
+}
+
+export const traverseTree = (
+  sourceFile: ts.SourceFile,
+  eachFn: (node: ts.Node) => void
+) => {
+  const stack: ts.Node[] = [sourceFile]
+
+  while (stack.length > 0) {
+    const node = stack.pop()
+    if (!node) {
+      continue
+    }
+    eachFn(node)
+    ts.forEachChild(node, child => {
+      stack.push(child)
+    })
+  }
+}
+
+const getLoaderTypeAndFlags = (
+  expr: ts.Expression
+): {
+  type: ConfigTsKeyType | null
+  isHidden: boolean
+  isNullable: boolean
+} => {
+  const propertyNames: string[] = []
+
+  const collectPropertyNames = (node: ts.Expression): void => {
+    if (ts.isPropertyAccessExpression(node)) {
+      propertyNames.push(node.name.text)
+      collectPropertyNames(node.expression)
+    } else if (ts.isCallExpression(node)) {
+      if (ts.isPropertyAccessExpression(node.expression)) {
+        collectPropertyNames(node.expression)
+      }
+    }
+  }
+  collectPropertyNames(expr)
+
+  const reversed = [...propertyNames].reverse()
+  let type: ConfigTsKeyType | null = null
+  for (const propName of reversed) {
+    if (
+      propName === 'string' ||
+      propName === 'number' ||
+      propName === 'bool' ||
+      propName === 'json' ||
+      propName === 'custom'
+    ) {
+      type = propName as ConfigTsKeyType
+      break
+    }
+  }
+
+  const isHidden = propertyNames.includes('hidden')
+  const isNullable = propertyNames.includes('nullable')
+
+  return { type, isHidden, isNullable }
+}
+
+const extractKeyFromCallExpression = (
+  callExpr: ts.CallExpression,
+  sourceFile: ts.SourceFile,
+  type: ConfigTsKeyType,
+  isHidden: boolean,
+  isNullable: boolean
+): ConfigTsKey | null => {
+  if (callExpr.arguments.length === 0) {
+    return null
+  }
+  const firstArg = callExpr.arguments[0]
+  if (!ts.isStringLiteral(firstArg)) {
+    return null
+  }
+  const start = firstArg.getStart(sourceFile)
+  const end = firstArg.getEnd()
+  return {
+    key: firstArg.text,
+    position: {
+      start,
+      end,
+    },
+    type,
+    isHidden,
+    isNullable,
+  }
+}
+
+const extractVariableName = (node: ts.VariableDeclaration): string | null => {
+  if (!node.initializer || !isCreateLoaderCall(node.initializer)) {
+    return null
+  }
+  if (!node.name || !ts.isIdentifier(node.name)) {
+    return null
+  }
+  return node.name.text
+}
+
+const extractAssignmentName = (node: ts.BinaryExpression): string | null => {
+  if (node.operatorToken.kind !== ts.SyntaxKind.EqualsToken) {
+    return null
+  }
+  if (!isCreateLoaderCall(node.right)) {
+    return null
+  }
+  if (!ts.isIdentifier(node.left)) {
+    return null
+  }
+  return node.left.text
+}
+
+const findLoaderVariables = (sourceFile: ts.SourceFile): Set<string> => {
+  const loaderVariables = new Set<string>()
+  traverseTree(sourceFile, node => {
+    // Checks variable declarations: const loader = createLoader(...)
+    if (ts.isVariableDeclaration(node)) {
+      const name = extractVariableName(node)
+      if (name) {
+        loaderVariables.add(name)
+      }
+    }
+    // Check expressions: loader = createLoader(...)
+    if (ts.isBinaryExpression(node)) {
+      const name = extractAssignmentName(node)
+      if (name) {
+        loaderVariables.add(name)
+      }
+    }
+  })
+  return loaderVariables
+}
+
+const isLoaderIdentifier = (
+  expr: ts.Expression,
+  loaderIdentifiers: Set<string>
+): boolean => {
+  if (ts.isIdentifier(expr)) {
+    return loaderIdentifiers.has(expr.text)
+  }
+  if (ts.isPropertyAccessExpression(expr)) {
+    return isLoaderIdentifier(expr.expression, loaderIdentifiers)
+  }
+  return false
+}
+
+const extractFromSimpleCall = (
+  callExpr: ts.CallExpression,
+  loaderIdentifiers: Set<string>,
+  sourceFile: ts.SourceFile
+): ConfigTsKey | null => {
+  if (!ts.isPropertyAccessExpression(callExpr.expression)) {
+    return null
+  }
+  if (!isLoaderIdentifier(callExpr.expression.expression, loaderIdentifiers)) {
+    return null
+  }
+
+  const { type, isHidden, isNullable } = getLoaderTypeAndFlags(
+    callExpr.expression
+  )
+  if (!type) {
+    return null
+  }
+
+  return extractKeyFromCallExpression(
+    callExpr,
+    sourceFile,
+    type,
+    isHidden,
+    isNullable
+  )
+}
+
+const extractFromChainedCall = (
+  callExpr: ts.CallExpression,
+  loaderIdentifiers: Set<string>,
+  sourceFile: ts.SourceFile
+): ConfigTsKey | null => {
+  if (!ts.isCallExpression(callExpr.expression)) {
+    return null
+  }
+  if (!ts.isPropertyAccessExpression(callExpr.expression.expression)) {
+    return null
+  }
+
+  const propAccess = callExpr.expression.expression
+  const isChained = ts.isPropertyAccessExpression(propAccess.expression)
+  const loaderExpr = isChained
+    ? propAccess.expression.expression
+    : propAccess.expression
+
+  if (!isLoaderIdentifier(loaderExpr, loaderIdentifiers)) {
+    return null
+  }
+
+  // For loader.custom(...)(), we need to check the property access before the inner call
+  const { type, isHidden, isNullable } = getLoaderTypeAndFlags(
+    callExpr.expression.expression
+  )
+  if (!type) {
+    return null
+  }
+
+  return extractKeyFromCallExpression(
+    callExpr,
+    sourceFile,
+    type,
+    isHidden,
+    isNullable
+  )
+}
+
+const tryExtractKey = (
+  callExpr: ts.CallExpression,
+  loaderIdentifiers: Set<string>,
+  sourceFile: ts.SourceFile
+): ConfigTsKey | null => {
+  const simpleKey = extractFromSimpleCall(
+    callExpr,
+    loaderIdentifiers,
+    sourceFile
+  )
+  if (simpleKey) {
+    return simpleKey
+  }
+  return extractFromChainedCall(callExpr, loaderIdentifiers, sourceFile)
+}
+
+export const extractConfiguruKeys = (sourceText: string): ConfigTsKey[] => {
+  const sourceFile = ts.createSourceFile(
+    'temp.ts',
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true
+  )
+  const loaderIdentifiers = findLoaderVariables(sourceFile)
+  const keys: ConfigTsKey[] = []
+  const seenKeys = new Set<string>()
+
+  traverseTree(sourceFile, node => {
+    if (ts.isCallExpression(node)) {
+      const keyData = tryExtractKey(node, loaderIdentifiers, sourceFile)
+      if (keyData && !seenKeys.has(keyData.key)) {
+        keys.push(keyData)
+        seenKeys.add(keyData.key)
+      }
+    }
+  })
+  return keys
+}

--- a/src/components/context.ts
+++ b/src/components/context.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import type { ConfigTsKey } from './config-ts-parser'
 import { ConfiguruEvent, ConfiguruEventType } from './event'
 import { helpers } from './helpers'
 import { ui } from './ui'
@@ -20,6 +21,7 @@ export interface ContextCache {
   fileTexts: Map<string, string>
   fileParsed: Map<string, Record<string, any>>
   fileUris: Map<string, vscode.Uri>
+  configTsKeys: Map<string, ConfigTsKey[]>
 }
 
 export const Features = [
@@ -40,6 +42,7 @@ const cache: ContextCache = {
   fileTexts: new Map(),
   fileParsed: new Map(),
   fileUris: new Map(),
+  configTsKeys: new Map(),
 }
 export interface ConfiguruExtConfig {
   features: ConfiguruFeatureFlags
@@ -135,6 +138,7 @@ const deleteFileCache = (event: ConfiguruEvent, fileName: string) => {
   event.context.cache.files.delete(fileName)
   event.context.cache.fileTexts.delete(fileName)
   event.context.cache.fileParsed.delete(fileName)
+  event.context.cache.configTsKeys.delete(fileName)
 }
 
 const clean = (event?: ConfiguruEvent) => {
@@ -144,6 +148,7 @@ const clean = (event?: ConfiguruEvent) => {
     contextCache.fileTexts.clear()
     contextCache.fileParsed.clear()
     contextCache.fileUris.clear()
+    contextCache.configTsKeys.clear()
     return
   }
   if (

--- a/src/components/helpers.ts
+++ b/src/components/helpers.ts
@@ -1,6 +1,7 @@
 import * as jsonParser from 'jsonc-parser'
 import * as vscode from 'vscode'
 import type { ConfiguruCacheValue, ContextCache } from './context'
+import { extractConfiguruKeys, type ConfigTsKey } from './config-ts-parser'
 import {
   ConfiguruEvent,
   FileEvent,
@@ -89,6 +90,14 @@ const getFiles = async (
   return vscode.workspace.openTextDocument(uri)
 }
 
+const getConfigTsKeys = async (
+  event: ConfiguruEvent,
+  fileName: string
+): Promise<ConfigTsKey[]> => {
+  const fileText = await getFileText(event, fileName)
+  return extractConfiguruKeys(fileText)
+}
+
 const contextDataloader =
   <
     Key extends keyof ContextCache,
@@ -130,5 +139,6 @@ export const helpers = {
     getFileUris: contextDataloader(getFileUri, 'fileUris'),
     getFiles: contextDataloader(getFiles, 'files'),
     getEnvFilesParsed: contextDataloader(getEnvFileParsed, 'fileParsed'),
+    getConfigTsKeys: contextDataloader(getConfigTsKeys, 'configTsKeys'),
   },
 }


### PR DESCRIPTION
Instead of using regex, `confg.ts` files are now parsed using `typescript`. Highlighters use cached parsed value to get relevant configuration keys found in the `config.ts` files and their metadata (position, if they are nullable, hidden and their type).

Fixes https://github.com/AckeeCZ/configuru-extension/issues/23
Parser is crutial part of new feature https://github.com/AckeeCZ/configuru-extension/issues/8

REDMINE-94509